### PR TITLE
Fix example code in README.md

### DIFF
--- a/packages/components/src/draggable/README.md
+++ b/packages/components/src/draggable/README.md
@@ -51,17 +51,17 @@ const MyDraggable = () => (
 					elementId="draggable-panel"
 					transferData={ { } }
 				>
-				{
-					( { onDraggableStart, onDraggableEnd } ) => (
-						<div className="example-drag-handle" draggable>
-							<Dashicon
-								icon="move"
-								onDragStart={ onDraggableStart }
-								onDragEnd={ onDraggableEnd }
-							/>
-						</div>
-					)
-				}
+					{
+						( { onDraggableStart, onDraggableEnd } ) => (
+							<div className="example-drag-handle" draggable>
+								<Dashicon
+									icon="move"
+									onDragStart={ onDraggableStart }
+									onDragEnd={ onDraggableEnd }
+								/>
+							</div>
+						)
+					}
 				</Draggable>
 			</PanelBody>
 		</Panel>
@@ -84,17 +84,17 @@ const MyDraggable = ( { onDragStart, onDragEnd } ) => (
 					onDragStart={ onDragStart }
 					onDragEnd={ onDragEnd }
 				>
-				{
-					( { onDraggableStart, onDraggableEnd } ) => (
-						<div className="example-drag-handle" draggable>
-							<Dashicon
-								icon="move"
-								onDragStart={ onDraggableStart }
-								onDragEnd={ onDraggableEnd }
-							/>
-						</div>
-					)
-				}
+					{
+						( { onDraggableStart, onDraggableEnd } ) => (
+							<div className="example-drag-handle" draggable>
+								<Dashicon
+									icon="move"
+									onDragStart={ onDraggableStart }
+									onDragEnd={ onDraggableEnd }
+								/>
+							</div>
+						)
+					}
 				</Draggable>
 			</PanelBody>
 		</Panel>

--- a/packages/components/src/draggable/README.md
+++ b/packages/components/src/draggable/README.md
@@ -53,12 +53,13 @@ const MyDraggable = () => (
 				>
 				{
 					( { onDraggableStart, onDraggableEnd } ) => (
-						<Dashicon
-							icon="move"
-							onDragStart={ onDraggableStart }
-							onDragEnd={ onDraggableEnd }
-							draggable
-						/>
+						<div className="example-drag-handle" draggable>
+							<Dashicon
+								icon="move"
+								onDragStart={ onDraggableStart }
+								onDragEnd={ onDraggableEnd }
+							/>
+						</div>
 					)
 				}
 				</Draggable>
@@ -85,12 +86,13 @@ const MyDraggable = ( { onDragStart, onDragEnd } ) => (
 				>
 				{
 					( { onDraggableStart, onDraggableEnd } ) => (
-						<Dashicon
-							icon="move"
-							onDragStart={ onDraggableStart }
-							onDragEnd={ onDraggableEnd }
-							draggable
-						/>
+						<div className="example-drag-handle" draggable>
+							<Dashicon
+								icon="move"
+								onDragStart={ onDraggableStart }
+								onDragEnd={ onDraggableEnd }
+							/>
+						</div>
 					)
 				}
 				</Draggable>


### PR DESCRIPTION
As mentioned in #16916, it seems not to work to add "draggable" attribute directly to Dashicon. The example works when the Dashicon is wrapped in a div.

## Description
Wrapped Dashicon in README.md in a div.

## How has this been tested?
N.a.

## Screenshots <!-- if applicable -->
N.a.

## Types of changes
Changed readme